### PR TITLE
Fixes issue #13

### DIFF
--- a/atom/chromium_make.diff
+++ b/atom/chromium_make.diff
@@ -31,6 +31,15 @@
  		libcups.so:print/cups \
  		libfreetype.so:print/freetype2 \
  		libharfbuzz.so:print/harfbuzz \
+@@ -58,7 +56,7 @@
+ 		droid-fonts-ttf>0:x11-fonts/droid-fonts-ttf
+ 
+ ONLY_FOR_ARCHS=	i386 amd64
+-USES=		compiler bison cpe desktop-file-utils execinfo jpeg \
++USES=		compiler bison cpe desktop-file-utils jpeg \
+ 		ninja perl5 pkgconfig python:2,build shebangfix tar:xz
+ 
+ CPE_VENDOR=	google
 @@ -185,8 +183,8 @@
  
  .include <bsd.port.pre.mk>


### PR DESCRIPTION
Multiple people, including myself, @yonas, and @daviddpd have build issues due to execinfo.mk being required even though that file no longer exists in the ports tree.  Let's put this issue to bed for good.